### PR TITLE
weld: Use backends name over type for TestingBackends field name

### DIFF
--- a/internal/templates/testing.tmpl
+++ b/internal/templates/testing.tmpl
@@ -14,7 +14,7 @@ import (
 
 func NewTesting{{.BackendsName}}(b {{.BackendsType}}) *Testing{{.BackendsName}} {
 	return &Testing{{.BackendsName}}{
-		{{.BackendsType}}: b,
+		{{.BackendsName}}: b,
 	}
 }
 
@@ -32,7 +32,7 @@ func (ti *Testing{{$.BackendsName}}) {{.Getter}}() {{.Type}} {
        return ti.{{.Var}}
     }
 
-	return ti.Backends.{{.Getter}}()
+	return ti.{{$.BackendsName}}.{{.Getter}}()
 }
 {{end}}
 


### PR DESCRIPTION
currently you can get a result of:

`func NewTestingBackends(b other.Backends) *TestingBackends {
	return &TestingBackends{
		other.Backends: b,
	}
}`

This MR fixes it and uses the name of the backends instead of the type so it generates:

``func NewTestingBackends(b other.Backends) *TestingBackends {
	return &TestingBackends{
		Backends: b,
	}
}``