### PR TITLE
Allow generic named types to be directly used as a provider

### DIFF
--- a/internal/template.go
+++ b/internal/template.go
@@ -313,7 +313,6 @@ func makeTypeRef(pkgCache *PkgCache, typ types.Type) (string, error) {
 	}
 
 	res := typ.String()
-
 	for _, pkg := range pkgs {
 		if pkg.Path() == pkgCache.In {
 			res = strings.ReplaceAll(res, pkg.Path()+".", "")
@@ -553,6 +552,14 @@ func getTypePkgs(tl ...types.Type) ([]*types.Package, error) {
 			pkg := t.Obj().Pkg()
 			if pkg != nil {
 				pl = []*types.Package{pkg}
+			}
+
+			for i := 0; i < t.TypeArgs().Len(); i++ {
+				generics, err := getTypePkgs(t.TypeArgs().At(i))
+				if err != nil {
+					return nil, err
+				}
+				pl = append(pl, generics...)
 			}
 		case *types.Map:
 			pl, err = getTypePkgs(t.Elem(), t.Key())

--- a/internal/testdata/dev_exchange_graph.golden
+++ b/internal/testdata/dev_exchange_graph.golden
@@ -1,4 +1,4 @@
-Set[10]: (inline)
+Set[11]: (inline)
   Set[1]: var example/exchange/state.ChanProvider
     Func[1]: func example/exchange/state.NewModelChan() chan<- example/exchange.Model
   Set[9]: var example/backends/providers.WeldDev
@@ -14,3 +14,4 @@ Set[10]: (inline)
       Func[1]: func example/external/mail.New(opts ...example/external/mail.option) (*example/external/mail.Mailer, error)
       Func[1]: func example/external/mail/mail.New() (*example/external/mail/mail.MailerLegacy, error)
       Func[1]: func example/external/versioned.New() *example/external/versioned/v1.Service
+  Func[1]: func example/exchange/state.NewGenericStringType() example/exchange/ops.TestFunc[example/exchange.Model, string]

--- a/internal/testdata/dev_exchange_selected.golden
+++ b/internal/testdata/dev_exchange_selected.golden
@@ -1,6 +1,7 @@
 Func[1]: func example/exchange/db.Connect() (*example/exchange/db.ExchangeDB, error)
 Func[1]: func example/external/versioned.New() *example/external/versioned/v1.Service
 Func[1]: func example/exchange/state.NewModelChan() chan<- example/exchange.Model
+Func[1]: func example/exchange/state.NewGenericStringType() example/exchange/ops.TestFunc[example/exchange.Model, string]
 Func[1]: func example/identity/email/client/dev.Make(b example/identity/email/client/logical.Backends) (example/identity/email.Client, error)
 Func[1]: func example/identity/users/client/dev.Make(b example/identity/users/client/logical.Backends) (example/identity/users.Client, error)
 Func[1]: func example/identity/email/db.Connect() (*example/identity/email/db.EmailDB, error)

--- a/internal/testdata/dev_exchange_specBack.golden
+++ b/internal/testdata/dev_exchange_specBack.golden
@@ -1,1 +1,1 @@
-example/exchange/ops.Backends[5]: *example/exchange/db.ExchangeDB, *example/external/versioned/v1.Service, chan<- example/exchange.Model, example/identity/email.Client, example/identity/users.Client
+example/exchange/ops.Backends[6]: *example/exchange/db.ExchangeDB, *example/external/versioned/v1.Service, chan<- example/exchange.Model, example/exchange/ops.TestFunc[example/exchange.Model, string], example/identity/email.Client, example/identity/users.Client

--- a/internal/testdata/dev_exchange_tpldata.golden
+++ b/internal/testdata/dev_exchange_tpldata.golden
@@ -92,6 +92,16 @@ deps:
         returnserr: true
         params: []
         errwrapmsg: exchange db connect
+    - type: exchange_ops.TestFunc[exchange.Model, string]
+      var: genericStringFunc
+      getter: GenericStringFunc
+      isduplicate: false
+      provider:
+        funcpkg: exchange_state
+        funcname: NewGenericStringType
+        returnserr: false
+        params: []
+        errwrapmsg: exchange state new generic string type
     - type: chan<- exchange.Model
       var: modelChan
       getter: ModelChan

--- a/internal/testdata/dev_exchange_weldoutput.golden
+++ b/internal/testdata/dev_exchange_weldoutput.golden
@@ -42,6 +42,8 @@ func MakeBackends() (exchange_ops.Backends, error) {
 		return nil, errors.Wrap(err, "exchange db connect")
 	}
 
+	b.genericStringFunc = exchange_state.NewGenericStringType()
+
 	b.modelChan = exchange_state.NewModelChan()
 
 	b.users, err = users_client_dev.Make(&b)
@@ -60,13 +62,14 @@ func MakeBackends() (exchange_ops.Backends, error) {
 }
 
 type backendsImpl struct {
-	email      email.Client
-	emailDB    *email_db.EmailDB
-	exchangeDB *exchange_db.ExchangeDB
-	modelChan  chan<- exchange.Model
-	users      users.Client
-	usersDB    *users_db.UsersDB
-	versioned  *versioned_v1.Service
+	email             email.Client
+	emailDB           *email_db.EmailDB
+	exchangeDB        *exchange_db.ExchangeDB
+	genericStringFunc exchange_ops.TestFunc[exchange.Model, string]
+	modelChan         chan<- exchange.Model
+	users             users.Client
+	usersDB           *users_db.UsersDB
+	versioned         *versioned_v1.Service
 }
 
 func (b *backendsImpl) Email() email.Client {
@@ -79,6 +82,10 @@ func (b *backendsImpl) EmailDB() *email_db.EmailDB {
 
 func (b *backendsImpl) ExchangeDB() *exchange_db.ExchangeDB {
 	return b.exchangeDB
+}
+
+func (b *backendsImpl) GenericStringFunc() exchange_ops.TestFunc[exchange.Model, string] {
+	return b.genericStringFunc
 }
 
 func (b *backendsImpl) ModelChan() chan<- exchange.Model {

--- a/internal/testdata/example/exchange/ops/backends.go
+++ b/internal/testdata/example/exchange/ops/backends.go
@@ -8,7 +8,12 @@ import (
 	"example/identity/users"
 )
 
+type TestFunc[T any, C any] func(a T, c C) string
+
+type GenericStringType = TestFunc[exchange.Model, string]
+
 type Backends interface {
+	GenericStringFunc() GenericStringType
 	ExchangeDB() *db.ExchangeDB
 	Email() email.Client
 	Users() users.Client

--- a/internal/testdata/example/exchange/state/adhoc.go
+++ b/internal/testdata/example/exchange/state/adhoc.go
@@ -2,7 +2,9 @@ package state
 
 import (
 	"example/exchange"
+	"fmt"
 
+	exchange_ops "example/exchange/ops"
 	"github.com/luno/weld"
 )
 
@@ -10,4 +12,10 @@ var ChanProvider = weld.NewSet(NewModelChan)
 
 func NewModelChan() chan<- exchange.Model {
 	return make(chan<- exchange.Model)
+}
+
+func NewGenericStringType() exchange_ops.GenericStringType {
+	return func(a exchange.Model, b string) string {
+		return fmt.Sprintf("%s%s", a, b)
+	}
 }

--- a/internal/testdata/example/exchange/state/devstate/weld.go
+++ b/internal/testdata/example/exchange/state/devstate/weld.go
@@ -13,6 +13,10 @@ import (
 //go:generate weld
 
 var _ = weld.NewSpec(
-	weld.NewSet(state.ChanProvider, providers.WeldDev),
+	weld.NewSet(
+		state.ChanProvider,
+		providers.WeldDev,
+		state.NewGenericStringType,
+	),
 	weld.Existing(new(exchange_ops.Backends)),
 )

--- a/internal/testdata/example/exchange/state/devstate/weld_gen.go
+++ b/internal/testdata/example/exchange/state/devstate/weld_gen.go
@@ -42,6 +42,8 @@ func MakeBackends() (exchange_ops.Backends, error) {
 		return nil, errors.Wrap(err, "exchange db connect")
 	}
 
+	b.genericStringFunc = exchange_state.NewGenericStringType()
+
 	b.modelChan = exchange_state.NewModelChan()
 
 	b.users, err = users_client_dev.Make(&b)
@@ -60,13 +62,14 @@ func MakeBackends() (exchange_ops.Backends, error) {
 }
 
 type backendsImpl struct {
-	email      email.Client
-	emailDB    *email_db.EmailDB
-	exchangeDB *exchange_db.ExchangeDB
-	modelChan  chan<- exchange.Model
-	users      users.Client
-	usersDB    *users_db.UsersDB
-	versioned  *versioned_v1.Service
+	email             email.Client
+	emailDB           *email_db.EmailDB
+	exchangeDB        *exchange_db.ExchangeDB
+	genericStringFunc exchange_ops.TestFunc[exchange.Model, string]
+	modelChan         chan<- exchange.Model
+	users             users.Client
+	usersDB           *users_db.UsersDB
+	versioned         *versioned_v1.Service
 }
 
 func (b *backendsImpl) Email() email.Client {
@@ -79,6 +82,10 @@ func (b *backendsImpl) EmailDB() *email_db.EmailDB {
 
 func (b *backendsImpl) ExchangeDB() *exchange_db.ExchangeDB {
 	return b.exchangeDB
+}
+
+func (b *backendsImpl) GenericStringFunc() exchange_ops.TestFunc[exchange.Model, string] {
+	return b.genericStringFunc
 }
 
 func (b *backendsImpl) ModelChan() chan<- exchange.Model {

--- a/internal/testdata/example/exchange/state/weld.go
+++ b/internal/testdata/example/exchange/state/weld.go
@@ -13,6 +13,10 @@ import (
 // Note that github.com/luno/weld/internal/gen_test.go generates this specific state_gen.go as well.
 
 var _ = weld.NewSpec(
-	weld.NewSet(ChanProvider, providers.WeldProd),
+	weld.NewSet(
+		ChanProvider,
+		providers.WeldProd,
+		NewGenericStringType,
+	),
 	weld.Existing(new(exchange_ops.Backends)),
 )

--- a/internal/testdata/example/exchange/state/weld_gen.go
+++ b/internal/testdata/example/exchange/state/weld_gen.go
@@ -34,6 +34,8 @@ func MakeBackends() (exchange_ops.Backends, error) {
 		return nil, errors.Wrap(err, "exchange db connect")
 	}
 
+	b.genericStringFunc = NewGenericStringType()
+
 	b.modelChan = NewModelChan()
 
 	b.users, err = users_client_grpc.New()
@@ -47,11 +49,12 @@ func MakeBackends() (exchange_ops.Backends, error) {
 }
 
 type backendsImpl struct {
-	email      email.Client
-	exchangeDB *exchange_db.ExchangeDB
-	modelChan  chan<- exchange.Model
-	users      users.Client
-	versioned  *versioned_v1.Service
+	email             email.Client
+	exchangeDB        *exchange_db.ExchangeDB
+	genericStringFunc exchange_ops.TestFunc[exchange.Model, string]
+	modelChan         chan<- exchange.Model
+	users             users.Client
+	versioned         *versioned_v1.Service
 }
 
 func (b *backendsImpl) Email() email.Client {
@@ -60,6 +63,10 @@ func (b *backendsImpl) Email() email.Client {
 
 func (b *backendsImpl) ExchangeDB() *exchange_db.ExchangeDB {
 	return b.exchangeDB
+}
+
+func (b *backendsImpl) GenericStringFunc() exchange_ops.TestFunc[exchange.Model, string] {
+	return b.genericStringFunc
 }
 
 func (b *backendsImpl) ModelChan() chan<- exchange.Model {

--- a/internal/testdata/exchange_graph.golden
+++ b/internal/testdata/exchange_graph.golden
@@ -1,4 +1,4 @@
-Set[13]: (inline)
+Set[14]: (inline)
   Set[1]: var example/exchange/state.ChanProvider
     Func[1]: func example/exchange/state.NewModelChan() chan<- example/exchange.Model
   Set[12]: var example/backends/providers.WeldProd
@@ -20,3 +20,4 @@ Set[13]: (inline)
       Func[1]: func example/external/mail.New(opts ...example/external/mail.option) (*example/external/mail.Mailer, error)
       Func[1]: func example/external/mail/mail.New() (*example/external/mail/mail.MailerLegacy, error)
       Func[1]: func example/external/versioned.New() *example/external/versioned/v1.Service
+  Func[1]: func example/exchange/state.NewGenericStringType() example/exchange/ops.TestFunc[example/exchange.Model, string]

--- a/internal/testdata/exchange_selected.golden
+++ b/internal/testdata/exchange_selected.golden
@@ -1,6 +1,7 @@
 Func[1]: func example/exchange/db.Connect() (*example/exchange/db.ExchangeDB, error)
 Func[1]: func example/external/versioned.New() *example/external/versioned/v1.Service
 Func[1]: func example/exchange/state.NewModelChan() chan<- example/exchange.Model
+Func[1]: func example/exchange/state.NewGenericStringType() example/exchange/ops.TestFunc[example/exchange.Model, string]
 Bind[1]: example/identity/email.Client(*example/identity/email/client/grpc.client)
 Bind[1]: example/identity/users.Client(*example/identity/users/client/grpc.client)
 Func[1]: func example/identity/email/client/grpc.New() (*example/identity/email/client/grpc.client, error)

--- a/internal/testdata/exchange_specBack.golden
+++ b/internal/testdata/exchange_specBack.golden
@@ -1,1 +1,1 @@
-example/exchange/ops.Backends[5]: *example/exchange/db.ExchangeDB, *example/external/versioned/v1.Service, chan<- example/exchange.Model, example/identity/email.Client, example/identity/users.Client
+example/exchange/ops.Backends[6]: *example/exchange/db.ExchangeDB, *example/external/versioned/v1.Service, chan<- example/exchange.Model, example/exchange/ops.TestFunc[example/exchange.Model, string], example/identity/email.Client, example/identity/users.Client

--- a/internal/testdata/exchange_tpldata.golden
+++ b/internal/testdata/exchange_tpldata.golden
@@ -61,6 +61,16 @@ deps:
         returnserr: true
         params: []
         errwrapmsg: exchange db connect
+    - type: exchange_ops.TestFunc[exchange.Model, string]
+      var: genericStringFunc
+      getter: GenericStringFunc
+      isduplicate: false
+      provider:
+        funcpkg: ""
+        funcname: NewGenericStringType
+        returnserr: false
+        params: []
+        errwrapmsg: exchange state new generic string type
     - type: chan<- exchange.Model
       var: modelChan
       getter: ModelChan

--- a/internal/testdata/exchange_weldoutput.golden
+++ b/internal/testdata/exchange_weldoutput.golden
@@ -34,6 +34,8 @@ func MakeBackends() (exchange_ops.Backends, error) {
 		return nil, errors.Wrap(err, "exchange db connect")
 	}
 
+	b.genericStringFunc = NewGenericStringType()
+
 	b.modelChan = NewModelChan()
 
 	b.users, err = users_client_grpc.New()
@@ -47,11 +49,12 @@ func MakeBackends() (exchange_ops.Backends, error) {
 }
 
 type backendsImpl struct {
-	email      email.Client
-	exchangeDB *exchange_db.ExchangeDB
-	modelChan  chan<- exchange.Model
-	users      users.Client
-	versioned  *versioned_v1.Service
+	email             email.Client
+	exchangeDB        *exchange_db.ExchangeDB
+	genericStringFunc exchange_ops.TestFunc[exchange.Model, string]
+	modelChan         chan<- exchange.Model
+	users             users.Client
+	versioned         *versioned_v1.Service
 }
 
 func (b *backendsImpl) Email() email.Client {
@@ -60,6 +63,10 @@ func (b *backendsImpl) Email() email.Client {
 
 func (b *backendsImpl) ExchangeDB() *exchange_db.ExchangeDB {
 	return b.exchangeDB
+}
+
+func (b *backendsImpl) GenericStringFunc() exchange_ops.TestFunc[exchange.Model, string] {
+	return b.genericStringFunc
 }
 
 func (b *backendsImpl) ModelChan() chan<- exchange.Model {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectName = weld
 sonar.links.scm = https://github.com/luno/weld
 
 sonar.sources = .
-sonar.exclusions=**/*_test.go, **/*pb.go
+sonar.exclusions=**/*_test.go, **/*pb.go, internal/testdata/**
 sonar.go.coverage.reportPaths = coverage.out
 sonar.go.tests.reportPaths = sonar-report.json
 sonar.tests = .


### PR DESCRIPTION
Using a generic function as a provider cased issued when the func had named types like so:

```
type TestFunc[T any, C any] func(a T, c C) string
type GenericStringType = TestFunc[exchange.Model, string]

type Backends interface { 
    GenericStringFunc() GenericStringType
}
```

When generating the weld code, it would fail since it tried to generate the function signature like this:

```
func (b *backendsImpl) GenericStringFunc() exchange_ops.TestFunc[example/exchange.Model, string] {
	return b.genericStringFunc
}
```

The type arguments were not included in the template "package replacement" code. It would only go over the `exchange_ops.TestFunc`, but not it's arguments.

Adding the type arguments to the `Named` type clause seems to solve this issue and it not correctly replaces the `example/` directory from the package name.

