### PR TITLE
gomod: Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/weld
 
-go 1.23.2
+go 1.24.3
 
 require (
 	github.com/luno/jettison v0.0.0-20240722160230-b42bd507a5f6


### PR DESCRIPTION
## Changed

- Updated Go version from 1.23.2 to 1.24.3 in go.mod

## Rationale

Updating to the latest Go version (1.24.3) provides improved performance, security fixes, and access to the latest language features and standard library improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go module version to 1.24.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->