### PR TITLE
ci: use env.SONAR_TOKEN in sonar workflow

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Upload coverage reports to Sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        if: github.event.pull_request.head.repo.full_name == github.repository || secrets.SONAR_TOKEN != ''
+        if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v5.3.0


### PR DESCRIPTION
Use env.SONAR_TOKEN in the step-level if expression because GitHub Actions disallows direct access to secrets inside expressions. This avoids the 'Unrecognized named-value: secrets' parser error while keeping the secret available to the action via env.