### PR TITLE
weld: Fix typo when dependency can't be found

### DIFF
--- a/internal/template.go
+++ b/internal/template.go
@@ -308,7 +308,7 @@ func makeTplDep(
 		}
 	}
 
-	return nil, errors.New("dep no found", j.MKV{"getter": getter, "type": dep})
+	return nil, errors.New("dep not found", j.MKV{"getter": getter, "type": dep})
 }
 
 // makeTypeRef return the type reference; including package alias or without package if input package.


### PR DESCRIPTION
Just fixes a small typo in one of the errors when a dependency can't be found. Doesn't seem like there's any tests that need to be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message text displayed when template dependencies cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->