### PR TITLE
go: Update Go version to 1.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/luno/weld
 
-go 1.26.0
+go 1.27.0
 
-toolchain go1.26.3
+toolchain go1.27.1
 
 require (
 	github.com/luno/jettison v0.0.0-20260604094545-6727dacc9313


### PR DESCRIPTION
This PR updates the Go version in Weld from 1.26.3 to 1.27.1.

This is part of the Go version upgrade process across our backend services. This PR must be merged and released before we can proceed with updating the core repository's dependencies.

Changes:

Updated go.mod to specify Go 1.27.1
Impact:

No breaking changes expected
This will allow core services to use Go 1.27.1 features
Next Steps:

Merge this PR
Wait for Weld release/tag to be available
Update core repository dependencies to reference new Weld version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Go language version and toolchain requirements to newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->